### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: ["main"]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/hasssan/node-esm-starter/security/code-scanning/1](https://github.com/hasssan/node-esm-starter/security/code-scanning/1)

In general, the fix is to explicitly restrict the GITHUB_TOKEN permissions in the workflow to the minimum required. For this particular Node.js CI workflow, the steps only read repository contents and install/run local tooling. They do not need to write to the repository, issues, or pull requests. Therefore, we can add a `permissions:` block with `contents: read` (and optionally other read-only scopes if later needed). This should be added either at the workflow root (to apply to all jobs) or specifically under the `build` job; the simplest least-disruptive change is to add it at the root.

Concretely, in `.github/workflows/node.js.yml`, insert a `permissions:` section after the `on:` block and before the `jobs:` key. This will apply to all jobs in this workflow, including `build`. The block should look like:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or other definitions are required since this is a YAML configuration change only, and it does not alter the functional steps of the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
